### PR TITLE
added rt.awstaticdn.net to blocklist

### DIFF
--- a/road-block-filters.txt
+++ b/road-block-filters.txt
@@ -99,4 +99,6 @@ www.biziday.ro##A[href="https://www.aegonmarket.ro/"]
 www.biziday.ro##A[href="https://www.bancatransilvania.ro/pentru-companii/imm/credite-imm/investeste-romaneste/"]
 www.biziday.ro##DIV[id="_tdv_all"]
 
-||contestapp.a1.ro
+!Pop-up Ads
+||contestapp.a1.ro^
+||rt.awstaticdn.net^


### PR DESCRIPTION
Adaugat rt.awstaticdn.net in lista de interziceri. Acest website adauga ferestre de tip pop-up in care forteza utilizatorii sa instaleze plugin-uri pentru navigatoare.
![rt.awstaticdn.net](http://i.imgur.com/76vtb4D.png)