### PR TITLE
Fix awstaticdn popup block

### DIFF
--- a/road-block-filters.txt
+++ b/road-block-filters.txt
@@ -102,7 +102,9 @@ nosteam.ro###stickynote4
 ||terrapops.com^$popup
 
 !Pop-up Ads
-||*.awstaticdn.net^
+||awstaticdn.net^
+||dl14.awstaticdn.net^
+||rt.awstaticdn.net^
 ||contestapp.a1.ro^
 
 ||cloudfront.net$script,domain=playfs.com


### PR DESCRIPTION
Se pare ca sintaxa * nu inlocuieste subdomeniile trebuiesc declarate toate.
Pana acum doar rt.awstaticdn.net si dl14.awstaticdn.net .

![awstaticdn.net](http://i.imgur.com/76vtb4D.png)