### PR TITLE
fix bannersnack.com

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -385,7 +385,7 @@ emag.ro##.ns-wrap-bottom-right
 ||ads.tradeads.eu^
 ||adservingfactory.com^
 ||amazonaws.com/newd.cetrk.com/
-||bannersnack.com^
+||bannersnack.com^$third-party
 ||brat-online.ro^
 ||chargeplatform.com^
 ||evensys.ro^$third-party

--- a/road-block-filters.txt
+++ b/road-block-filters.txt
@@ -385,7 +385,7 @@ emag.ro##.ns-wrap-bottom-right
 ||ads.tradeads.eu^
 ||adservingfactory.com^
 ||amazonaws.com/newd.cetrk.com/
-||bannersnack.com^
+||bannersnack.com^$third-party
 ||brat-online.ro^
 ||chargeplatform.com^
 ||evensys.ro^$third-party


### PR DESCRIPTION
The **website, app and blog of bannersnack.com** is _broken_ due to the rule. I have made this **PR** to adjust the blocking **_on third party domains only_**, thus, allowing the bannersnack apps to work properly.

Affected domains:
https://www.bannersnack.com
https://app.bannersnack.com
https://blog.bannersnack.com