### PR TITLE
Coinhive is dead

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -19,6 +19,7 @@
 ||psd.marketing^$third-party
 ||paydemic.com
 
+coinhive.min.js
 ||jsecoin.com^
 ||reasedoper.pw^
 ||mataharirama.xyz^

--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -3,7 +3,7 @@
 ! Expires: 3 days
 ! Issue tracker: https://github.com/tcptomato/ROad-Block/issues
 ! Homepage: https://www.adblock.ro
-! Last modified: 01 Sep 2021 13:55 UTC
+! Last modified: 15 Dec 2021 11:21 UTC
 
 /adblock.js
 /plugins/footer-pop-up-banner/*
@@ -19,9 +19,6 @@
 ||psd.marketing^$third-party
 ||paydemic.com
 
-coinhive.min.js
-||coin-hive.com^
-||coinhive.com^
 ||jsecoin.com^
 ||reasedoper.pw^
 ||mataharirama.xyz^

--- a/road-block-filters.txt
+++ b/road-block-filters.txt
@@ -233,6 +233,7 @@
 ||psd.marketing^$third-party
 ||paydemic.com
 
+coinhive.min.js
 ||jsecoin.com^
 ||reasedoper.pw^
 ||mataharirama.xyz^

--- a/road-block-filters.txt
+++ b/road-block-filters.txt
@@ -3,7 +3,7 @@
 ! Expires: 2 days
 ! Issue tracker: https://github.com/tcptomato/ROad-Block/issues
 ! Homepage: https://www.adblock.ro
-! Last modified: 18 Sept 2020 13:55 UTC
+! Last modified: 15 Dec 2021 11:22 UTC
 
 ! ROAD Kill - site-uri de whitelistuit manual
 ! Lista fantoma | Anti-spam | Site-uri periculoase
@@ -233,9 +233,6 @@
 ||psd.marketing^$third-party
 ||paydemic.com
 
-coinhive.min.js
-||coin-hive.com^
-||coinhive.com^
 ||jsecoin.com^
 ||reasedoper.pw^
 ||mataharirama.xyz^


### PR DESCRIPTION
This PR removes the blocks on CoinHive, because it is dead. 

https://user-images.githubusercontent.com/84232764/146224676-bad77e9d-8da7-44e3-b6fa-ba910169d618.mp4

## Steps
- Go to `https://coinhive.com`
- Disable strictblocking
- Note that it redirects to `https://www.troyhunt.com/i-now-own-the-coinhive-domain-heres-how-im-fighting-cryptojacking-and-doing-good-things-with-content-security-policies/`

The script it's self (`https://coinhive.com/lib/coinhive.min.js`) has been modified as well:
![image](https://user-images.githubusercontent.com/84232764/146225176-1d135ac0-e0a4-4503-98e6-dd493a82647c.png)

