### PR TITLE
click. ro

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -876,3 +876,6 @@ reno.ro##.adsense
 rasfoiesc.com##[style^="overflow:"]:has([data-ad])
 rasfoiesc.com##[style^="overflow:"]:has([data-ad-slot])
 rasfoiesc.com##td[height^="500"]
+
+click.ro##.google-ads-in_article
+click.ro##.google-ads-billboard


### PR DESCRIPTION
tested on `https://click.ro/` and `https://click.ro/actualitate/national/povestea-fetelor-salvate-din-foc-la-iasi-bunicul-410758.html`