### PR TITLE
focuspress .ro

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -954,3 +954,8 @@ ampress.ro##.widget_fmowr.widget
 rnews.ro##.add728x90
 rnews.ro##[href="http://www.epamedia.ro"]
 rnews.ro##[href="http://www.messages2autdoor.ro"]
+
+||focuspress.ro/wp-content/uploads/*/*/AD*.jpg$image
+focuspress.ro##[class*="td_spot_img"]
+focuspress.ro##.widget_media_image
+focuspress.ro##.td-header-header


### PR DESCRIPTION
filters were tested on `https://focuspress.ro/` and `https://focuspress.ro/cati-oameni-se-pot-refugia-in-caz-de-razboi-in-cele-10-adaposturi-de-protectie-civila-din-mangalia/`

Oh, and I don't remember if I encountered a betting ad on any of the URL's (before coming up with the filters which I added in this PR)