### PR TITLE
posturi. live | anti-popup filter

### DIFF
--- a/road-ubo.txt
+++ b/road-ubo.txt
@@ -22,5 +22,5 @@ sport.ro##*:matches-css-before(content:/ADVERTISING/):remove()
 ! https://github.com/tcptomato/ROad-Block/issues/213
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=as.ro
 
-! anti-popup
+! popup
 posturi.live##+js(nowoif)

--- a/road-ubo.txt
+++ b/road-ubo.txt
@@ -21,3 +21,6 @@ sport.ro##*:matches-css-before(content:/ADVERTISING/):remove()
 
 ! https://github.com/tcptomato/ROad-Block/issues/213
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=as.ro
+
+! anti-popup
+posturi.live##+js(nowoif)


### PR DESCRIPTION
After attempting to view footage from `https://posturi.live/tv/pro-tv`, there seems to be some sort of "popup" as well as something blocked by `||greatdexchange.com^$popup` (filter from EasyList)