### PR TITLE
bursa.ro - ads

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -1316,4 +1316,6 @@ monitoruldevrancea.ro#?#.widget_rss:-abp-has([href*=".bursa.ro/"])
 monitoruldevrancea.ro##[class*="td-a-rec-id-custom_ad"]
 monitoruldevrancea.ro##[href="https://www.bursa.ro/"]
 
+bursa.ro#?#.clearfix [href][target="_blank"][rel]:-abp-has([alt][title][style])
+
 !#include road-ubo.txt


### PR DESCRIPTION
`https://www.bursa.ro/`

![image](https://user-images.githubusercontent.com/113248817/190180759-deb1eecb-5ebb-44c0-9a79-39bdc9deb7e8.png)


On `https://www.bursa.ro/studiu-coface-pentru-primul-semestru-al-anului-mediul-antreprenorial-pierderi-de-2-7-miliarde-lei-din-cauza-insolventelor-24876746`, there seem to be 2 "ads" more towards the right -- lower side of the webpage; when I opened uBO element picker, they got hidden -- is this related with the supposed selector bug?