### PR TITLE
filme-bune. biz - ad

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -1324,4 +1324,7 @@ gorjonline.ro#?#.container-wrapper > [href="https://www.gorjonline.ro/anunturi/"
 newmoney.ro#?#.sow-image-container:-abp-has([target="_blank"][rel])
 ||newmoney.ro/*Banner$image
 
+||filme-bune.biz^*.gif$image
+filme-bune.biz#?#.Wdgt:-abp-has([src*=".gif"])
+
 !#include road-ubo.txt


### PR DESCRIPTION
`https://filme-bune.biz/`


https://user-images.githubusercontent.com/113248817/190261758-d74664ab-d54a-44f3-bc9c-b4548bde28b5.png

---

`https://filme-bune.biz/amintiri-din-copilarie/`

https://user-images.githubusercontent.com/113248817/190261595-f829b663-bba7-4ea2-949d-e63875b7b87b.png

---

Also, should scriptlet be added (domain name is present in uBO's `uBlock filters` two times.)?