### PR TITLE
https://www.reddit.com/r/uBlockOrigin/comments/x9qoen/

### DIFF
--- a/road-ubo.txt
+++ b/road-ubo.txt
@@ -30,3 +30,6 @@ cool-etv.net##+js(acis, onload, noBackPlease)
 
 ! https://www.reddit.com/r/uBlockOrigin/comments/n3bjwx/ublock_detected_on_website/
 vwforum.ro##+js(nostif, adsbygoogle)
+
+! https://www.reddit.com/r/uBlockOrigin/comments/x9qoen/
+bloground.ro##+js(nostif, show)


### PR DESCRIPTION
There are these filters:

```
! https://www.reddit.com/r/uBlockOrigin/comments/x9qoen/
bloground.ro##+js(nostif, show)
```
which are present in uBlock Origin's `"uBlock filters"` and I believe `bloground.ro` is Romanian

Also, if the filter is removed from uAssets, could you announce in the reddit post?