### PR TITLE
antena3.ro video player

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -85,7 +85,6 @@ antena3.ro##aside > .bannerBox
 antena3.ro##body > .bannerGrey
 antena3.ro##.bannerBox
 antena3.ro##.desktop_only.grey.section
-antena3.ro##.ivmWrapper
 
 catchy.ro###footer-ads-section
 catchy.ro##.pin-it-button


### PR DESCRIPTION
`https://www.antena3.ro/emisiuni/in-fata-natiunii/sorin-cimpeanu-solutii-masa-calda-scoli-elevi-copii-romania-651888.html`

depending on screen size I suppose, scrolling down may be needed in order to encounter video player

@mapx- also, uBlock Origin's `uBlock filters - Unbreak` has a filter for `antena3.ro` which seems redundat given that there is https://github.com/tcptomato/ROad-Block/blob/master/road-block-filters-light.txt#L1285