### PR TITLE
computerblog. ro ads

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -1343,4 +1343,8 @@ prwave.ro##.image[height="250"][width="300"]
 
 dinpopor.ro##.a-wrap
 
+||computerblog.ro^*970x250$image
+||computerblog.ro^*600_300$image
+||computerblog.ro/banner/
+
 !#include road-ubo.txt


### PR DESCRIPTION
`https://www.computerblog.ro/telefoane/huawei-nova-y70-a-fost-lansat-in-romania.html`
https://user-images.githubusercontent.com/113248817/190847511-7489bf7d-5481-485b-b2be-c7c5da82b882.png

`https://www.computerblog.ro/telefoane/huawei-nova-y70-a-fost-lansat-in-romania.html`
https://user-images.githubusercontent.com/113248817/190847539-19256bc6-3ebe-4cf3-9500-ebec4729544d.png
https://user-images.githubusercontent.com/113248817/190847557-aa4837e8-6395-43df-b28c-fb0399e81f21.png
