### PR TITLE
turdanews. net - ad

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -1019,6 +1019,7 @@ moduri.ro#?#.widget-container:-abp-has([id="t5_zone_standard-ga"])
 moduri.ro#?#.widget-container:-abp-has(.adsbygoogle)
 
 turdanews.net##.elementor-widget-smartmag-codes
+turdanews.net##[href="https://viamso.ro/"]
 turdanews.net##.smartmag-widget-codes
 
 ||ziarulevenimentul.ro/data/_editor/$image


### PR DESCRIPTION
`https://turdanews.net/restaurantele-si-fast-food-urile-obligate-sa-afiseze-caloriile-dar-si-ce-contin-produsele-comercializate/`

<details><summary>screenshot</summary>

![image](https://user-images.githubusercontent.com/113248817/191737491-4effc879-98fb-45ad-81c2-22eda51eb529.png)

</details>