### PR TITLE
damboviteanul.com - ads

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -1386,4 +1386,7 @@ zvj.ro#?#.boxstire2head:-abp-contains(Publicitate)
 
 vloggeri.com##[href^="https://event.2performant.com/"]
 
+||damboviteanul.com^*.gif$image
+damboviteanul.com#?#.widget_custom_html:-abp-has([href][target=_blank]):not(*:-abp-has([href*="damboviteanul.com"])):not(*:-abp-has([id="widget_container_curs"]))
+
 !#include road-ubo.txt


### PR DESCRIPTION
`https://damboviteanul.com/2022/09/17/dorian-popa-si-a-deschis-fast-food-si-ofera-3-000-de-saorma-gratis/`

ads more to the right and also some are more towards the bottom of the page