### PR TITLE
useit.ro - elements

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -81,6 +81,7 @@ antena3.ro##body > .bannerGrey
 antena3.ro##.bannerBox
 antena3.ro##.desktop_only.grey.section
 antena3.ro###ivm-inread
+useit.ro##.ads
 ! near video
 jurnalul.ro#?#.special-box-pm > p:-abp-contains(Philip Morris)
 


### PR DESCRIPTION
URL: `https://useit.ro/digital/un-investitor-twitter-a-ras-de-elon-musk-cu-o-oferta-noua-pentru-companie-ce-suma-redusa-ar-fi-oferit-pentru-reteaua-de-socializare-20405.html`

<detials><summary> Screenshot: </summary>

![image](https://user-images.githubusercontent.com/122573224/212722772-42c75f34-fbb8-491c-9ff2-c694f558494c.png)

</details>