### PR TITLE
clujust.ro - ad

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -1239,6 +1239,7 @@ dezvaluiri.ro#?#[id^="media_image"]:not(*:-abp-has([href*="dezvaluiri.ro"]))
 
 ||clujust.ro/*banner$image
 ||clujust.ro/*.gif$image
+clujust.ro##[href*="utm_medium=banner"]
 clujust.ro##[id^="ad"]
 
 forum-auto.info#?#.ipsWidget_inner:-abp-has([href="https://e-husa.ro/"])


### PR DESCRIPTION
URL: `https://www.clujust.ro/a-fost-publicata-legea-care-prevede-pentru-ce-condamnari-poate-fi-exclus-din-profesie-un-avocat/`

Ad seemingly in article

`https://www.clujust.ro/wp-content/uploads/2022/10/image_6483441.jpg`