### PR TITLE
editiedevrancea.ro - ads

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -1835,4 +1835,7 @@ super-boost.ro##.border:has([href*="binance.com"])
 
 ||botosaneanul.ro/reclame/$image
 
+editiedevrancea.ro##[id^="media_image"]
+editiedevrancea.ro##.gridview-post-ad-two
+
 !#include road-ubo.txt


### PR DESCRIPTION
URL: `https://editiedevrancea.ro/2023/08/31/skoda-octavia-vanduta-la-licitatie-publica/`
ads in sidebars
ads under article