### PR TITLE
upd autoexpert.ro

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -986,9 +986,11 @@ forum.softpedia.com#?#.post_block:-abp-has([class^="guest"]):-abp-contains(Anunt
 dirtbike.ro##[class*="banner"]
 ||dirtbike.ro/*banner$image
 
+autoexpert.ro##.pub
 autoexpert.ro##.pubheader
+autoexpert.ro##[href="https://www.sab.ro/"]
 autoexpert.ro#?#.textwidget:-abp-has([target="_blank"])
-autoexpert.ro##[href="https://www.kia.ro/"]
+autoexpert.ro##[href^="https://www.porschefinance.ro/"]
 
 carzz.ro##[href^="https://www.carvertical.com/"]
 carzz.ro##.second_carvertical_noVin


### PR DESCRIPTION
`https://www.autoexpert.ro/top-2022-cele-mai-fiabile-masini-second-hand-pana-in-10-000-euro/`
=> ad above title
=> ad below title

`https://www.autoexpert.ro/`

=> ad

<details> <summary> Screenshot: </summary>

![image](https://github.com/tcptomato/ROad-Block/assets/144071104/48fc0155-ab72-49b6-94e8-d9514bab41c5)

</details>

I haven't seen the ad for Kia => removed the filter