### PR TITLE
address https://github.com/brave/adblock-lists/issues/1177

### DIFF
--- a/road-ubo.txt
+++ b/road-ubo.txt
@@ -88,3 +88,6 @@ onlyplay.online##+js(nowoif, , 10)
 
 ! https://github.com/uBlockOrigin/uAssets/issues/21915
 boardingpass.ro##+js(nostif, ai_adb)
+
+! https://github.com/brave/adblock-lists/issues/1177
+clujust.ro##+js(rmnt, script, ai_adb)


### PR DESCRIPTION
From https://github.com/brave/adblock-lists/issues/1177

detection at `https://www.clujust.ro`

![image](https://github.com/tcptomato/ROad-Block/assets/20338483/fb8daae0-efd0-4128-b8f4-dcabdaace8b9)

opera/ublock origin
