### PR TITLE
playtech.ro placeholders

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -680,6 +680,7 @@ retete.unica.ro##.sam_branding.hidden-xs
 
 petitchef.ro##div[class^="akcelo"]
 
+playtech.ro##.height-250:has([id^="div-gpt-ad"])
 playtech.ro##.height-sm-250.height-xs-300
 playtech.ro##.mg-bottom-10.text-center
 playtech.ro##.padding-top-10.padding-bottom-10


### PR DESCRIPTION
`https://playtech.ro/stiri/obiceiul-dubios-pe-care-il-avea-cetateanul-turc-principalul-suspect-in-cazul-crimei-din-dambovita-detalii-ciudate-ies-la-iveala-884598`
multiple placeholders within article