### PR TITLE
zicala. ro ads

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -1772,6 +1772,8 @@ clubmercedes.ro##.axd
 ||get-in-shape.beauty^
 ###sam_branding[style="min-height:250px;"]
 
-actualmehedinti.ro##.banner_wrapper
+zicala.ro##.theiaStickySidebar
+||director-web.helponline.ro^$third-party
+||roportal.ro^$third-party
 
 !#include road-ubo.txt


### PR DESCRIPTION
`https://zicala.ro/` 

- ads in right sidebar (scroll down) --> atlas vpn, emag, fashiondays etc
- unnecessary third-party connections