### PR TITLE
Undo vandalism of road-ubo.txt

### DIFF
--- a/road-ubo.txt
+++ b/road-ubo.txt
@@ -50,8 +50,6 @@ posturi.live##+js(acs, setTimeout, admc)
 ||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=qbebe.ro,redirect=google-ima.js,important
 ||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=divahair.ro,redirect=google-ima.js,important
 
-||sputniknews.*^$all
-
 filmeserialegratis.*,fsplayer.*##+js(nowoif)
 
 cinemagia.ro###banner_container_top


### PR DESCRIPTION
This is ROad-Block, the Romanian **_Ad_** Block Filter List. It is meant to be used for blocking **_ads_**.  It is not meant to be [the EU's censorship tool to impose its pathetic little sanctions on everyone](https://github.com/tcptomato/ROad-Block/issues/353#issuecomment-1483815797). Much less a toy for [some neo-nazi spawn of Ceausescu](https://github.com/mapx-) to try and force everyone else into [jerking off to Stepan Bandera](https://github.com/tcptomato/ROad-Block/commit/4814dc9516d1b85572c43b8b5fcd1e3b992f157f#r106015744) just like themselves.

So how about leaving the censorship of news outlets up to your little fake shit-hole's foreign-imposed government and starting to actually try and block all those **_ads_** you are currently letting through for overpriced and STD-ridden gypsy whores...