### PR TITLE
actualitateavranceana.ro ads

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -1476,6 +1476,7 @@ dexonline.net##[href="https://creditrapid.ro/"]
 
 actualitateavranceana.ro##[href="https://www.sipotehnokaronline.com/"]
 actualitateavranceana.ro##[href^="https://www.sviatoacademy.ro/"]
+actualitateavranceana.ro##.widget_media_image
 ||florariafocsani.ro/image/catalog/ADV/$image,third-party
 
 fileshare.ro#?#td[width="250"]:not(*:-abp-has([href*="fileshare.ro"]))


### PR DESCRIPTION
URL: `https://www.actualitateavranceana.ro/podul-de-la-prisaca-se-redeschide-luni-viteza-va-fi-limitata-la-10-km-h/`

ads in right sidebar
