### PR TITLE
turdanews.net ad

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -944,6 +944,7 @@ moduri.ro#?#.widget-container:-abp-has(.adsbygoogle)
 turdanews.net##.elementor-widget-smartmag-codes
 turdanews.net##[href="https://viamso.ro/"]
 turdanews.net##.smartmag-widget-codes
+turdanews.net##.widget_custom_html
 turdanews.net##.e-con-full
 turdanews.net##.ai-track
 


### PR DESCRIPTION
`https://turdanews.net/26-milioane-de-romani-vor-beneficia-in-luna-decembrie-de-o-noua-transa-de-250-de-lei-pentru-alimente/`

![image](https://github.com/user-attachments/assets/6aab849c-d716-4725-a680-3a081efb8a0a)
