### PR TITLE
antena3constanta.ro ad

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -1832,4 +1832,6 @@ jurnaldevrancea.ro##[alt="spot_img"]
 
 observatorconstanta.ro##.gofollow > [data-eio-rwidth="728"]
 
+||antena3constanta.ro/*/*728x90px.gif$image
+
 !#include road-ubo.txt


### PR DESCRIPTION
`https://antena3constanta.ro/2024/12/10/nou-ovidius-clinical-hospital-este-partener-acreditat-al-uk-pi-club/`

```adblock
||antena3constanta.ro/*/*728x90px.gif$image
```


![image](https://github.com/user-attachments/assets/32f6e19b-4cdb-4338-830d-c96e00c52e8f)
