### PR TITLE
peco-online.ro - breakage

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -1463,7 +1463,6 @@ ziaruldinmuscel.ro##.vc_empty_space
 mediastiri.ro##.td_spot_img_all
 
 peco-online.ro##tr[onclick*="revolut"]
-peco-online.ro#?#.card:-abp-has(.adsbygoogle)
 
 gazetavalceana.ro#?#.widget_text.widget:-abp-contains(Reclame)
 


### PR DESCRIPTION
`https://peco-online.ro/index.php`

search bucuresti => the info is hidden