### PR TITLE
upd presasm.ro

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -212,6 +212,9 @@ portalsm.ro#?#.st-sidebar-widget:-abp-has([src*="publicitate"])
 ||presasm.ro/*reclama$image
 presasm.ro#?#.widget:not(*:-abp-has([href*="presasm.ro"])):not(*:-abp-has([data-href*="facebook"]))
 presasm.ro##.wp-image-179110
+presasm.ro##.header-banner
+presasm.ro##.code-block
+presasm.ro##.ttpAds
 
 ||satumareonline.ro/*reclame$image
 satmareanul.net##.widget_custom_html


### PR DESCRIPTION
`https://www.presasm.ro/romania-si-bulgaria-intra-in-spatiul-schengen-de-la-1-ianuarie-2025/`


ads

```adblock
presasm.ro##.header-banner
presasm.ro##.code-block
presasm.ro##.ttpAds
```

![image](https://github.com/user-attachments/assets/e4e73076-1a97-4b82-b67a-882c6f927193)
![image](https://github.com/user-attachments/assets/17df0699-58ec-4a86-98dc-dd3d177d3499)
![image](https://github.com/user-attachments/assets/3c791767-619f-402e-82db-a7c4d7b0e87e)
