### PR TITLE
transilvania365.ro - ads in right sidebar

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -1846,4 +1846,6 @@ obiectiv.net##.widget_custom_html
 ||cdn.knd.ro/media/*/common/placeholders/$image
 wowbiz.ro,kanald.ro,kanald2.ro##.afis
 
+transilvania365.ro##.td-ss-main-sidebar > aside > .wp-block-image
+
 !#include road-ubo.txt


### PR DESCRIPTION
`https://transilvania365.ro/a-doua-condamnare-primita-de-aristotel-cancescu-fostul-presedinte-al-consiliului-judetean-brasov-a-fost-anulata/`
```adblock
transilvania365.ro##.td-ss-main-sidebar > aside > .wp-block-image
```