### PR TITLE
Remove nazi vandalism, censorship of non-anti-Georgescu news media and unnessecary breaking of Epoch Times

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -1807,19 +1807,6 @@ turdainfo.ro##.banner
 ! detection ziaruldeiasi
 @@||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=ziaruldeiasi.ro
 
-!spam => https://publicrecord.ro/2024/10/22/caruta-cu-troli-din-caracal-si-teoriile-conspirationiste/
-||olt-media.ro^
-||romania-unita.ro^
-||romania-noastra.ro^
-||jurnalul-militar.ro^
-||romanulnationalist.ro^
-||gazeta-romaneasca.ro^
-||universul-stirilor.ro^
-||romanii-liberi.ro^
-||ziarul-democrat.ro^
-||oltenia-actualitati.ro^
-||rezistentaromanesca.ro^
-
 bihon.ro##[href^="https://www.melindainstal.ro/"]
 
 ! popunders

--- a/road-block-filters.txt
+++ b/road-block-filters.txt
@@ -1719,17 +1719,4 @@ ziaruldinmuscel.ro##.vc_empty_space
 
 mediastiri.ro##.td_spot_img_all
 
-!spam => https://publicrecord.ro/2024/10/22/caruta-cu-troli-din-caracal-si-teoriile-conspirationiste/
-||olt-media.ro^
-||romania-unita.ro^
-||romania-noastra.ro^
-||jurnalul-militar.ro^
-||romanulnationalist.ro^
-||gazeta-romaneasca.ro^
-||universul-stirilor.ro^
-||romanii-liberi.ro^
-||ziarul-democrat.ro^
-||oltenia-actualitati.ro^
-||rezistentaromanesca.ro^
-
 !#include road-ubo.txt

--- a/road-ubo.txt
+++ b/road-ubo.txt
@@ -50,9 +50,6 @@ posturi.live##+js(acs, setTimeout, admc)
 ||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=qbebe.ro,redirect=google-ima.js,important
 ||imasdk.googleapis.com/js/sdkloader/ima3.js$script,domain=divahair.ro,redirect=google-ima.js,important
 
-||sputniknews.*^$all
-||sputnikglobe.*^$all
-
 filmeserialegratis.*,fsplayer.*##+js(nowoif)
 
 cinemagia.ro###banner_container_top

--- a/road-ubo.txt
+++ b/road-ubo.txt
@@ -107,11 +107,6 @@ business24.ro##.banner
 business24.ro##.branding-container
 business24.ro##div.banner-container
 
-! epochtimes-romania overlay
-subs.epochbase.com##.container
-epochtimes-romania.com##.modal__overlay
-epochtimes-romania.com##body:style(overflow: unset !important)
-
 ! stream player anti-adblock
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$xhr,method=get,domain=tvonline123.com
 


### PR DESCRIPTION
This is ROad-Block, the _Romanian **Ad Block Filter** List_. It is meant to be used for _**blocking ads**_.

It is not meant to be [the EU's censorship tool to impose its pathetic little sanctions on everyone](https://github.com/tcptomato/ROad-Block/issues/353#issuecomment-1483815797). Much less a toy for [some neo-nazi spawn of Antonescu and Ceausescu](https://github.com/mapx-) to [try and force everyone else](https://github.com/tcptomato/ROad-Block/pull/354) into [jerking off to Stepan Bandera](https://github.com/tcptomato/ROad-Block/commit/4814dc9516d1b85572c43b8b5fcd1e3b992f157f) [the way itself does](https://github.com/tcptomato/ROad-Block/commit/a818b1f25625c6d8a0537cb0d607cbe0942dd17f).

So how about leaving the censorship of news outlets up to your little fake shit-hole's foreign-imposed government and **_starting to actually try and block all those ads you are currently letting through_** like for your overpriced and STD-ridden gypsy whores...