### PR TITLE
obiectiv-sm.ro - ads

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -1345,7 +1345,9 @@ moise.ro##[href*="imobiliare.ro"]
 gadget.ro#?#[id^="block"]:-abp-has([src*="pub"])
 
 obiectiv-sm.ro##.ottowebAds
+obiectiv-sm.ro##.ads-banner-link
 obiectiv-sm.ro##.bk-sticksb-wrapper
+||obiectiv-sm.ro/wp-content/uploads/2023/*DEMOLARI-SM.jpg$image
 
 ||gedave.ro^*.gif
 


### PR DESCRIPTION
`https://obiectiv-sm.ro/`
`https://obiectiv-sm.ro/2025/03/17/trei-autoturisme-avariate-in-centru-de-tencuiala-desprinsa-de-pe-cladiri/`

ads (banners)

<details> <summary> Screenshots: </summary>

![image](https://github.com/user-attachments/assets/b556f9f9-1bdc-4e45-b306-65175e04052d)
![image](https://github.com/user-attachments/assets/f2e15e33-4996-42a3-9cef-76fb8d0fa5be)


</details>