### PR TITLE
Remove dead nationalisti.ro domain

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -825,9 +825,6 @@ ziare.com##[id^="div-gpt-ad"]
 
 b365.ro##.height-250:has(.strawberry-ads)
 
-nationalisti.ro##.widget-container:has(ins.adsbygoogle)
-nationalisti.ro##[href="https://www.incorectpolitic.com"]
-
 incorectpolitic.com##.widget-container:has([href^="http://thecryptobot.com"])
 
 divahair.ro##.featuredBrandsCon


### PR DESCRIPTION
The domain is dead.

<img width="1913" height="146" alt="image" src="https://github.com/user-attachments/assets/06adc91c-b27e-4e15-925e-37bc7f201a10" />
