### PR TITLE
Add new ad filter for observatornews.ro

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -1991,6 +1991,7 @@ kimbino.ro##.ad
 observatornews.ro##.outstream-text:has(.banner)
 observatornews.ro##.vertical-add-container
 observatornews.ro##.new-ad
+observatornews.ro##.ad-special
 
 acasatv.protv.ro##[id]:has(script)
 


### PR DESCRIPTION
They inserted a new leftover on articles:

<img width="1388" height="874" alt="image" src="https://github.com/user-attachments/assets/9c28d47a-2675-4c7f-ab87-096fec93616f" />

`https://observatornews.ro/eveniment/un-tanar-a-facut-prapad-la-upu-gaesti-a-distrus-sala-si-a-amenintat-medicii-663502.html`