### PR TITLE
financiarpress.ro ads

### DIFF
--- a/road-block-filters-light.txt
+++ b/road-block-filters-light.txt
@@ -2617,4 +2617,7 @@ opiniavl.ro##.widget:has-text(Publicitate)
 
 infocontact.ro##aside.ad-container
 
+financiarpress.ro##[href]:not([href*="financiarpress.ro"], [href^="/"], [href*="#"]):has([src])
+||financiarpress.ro/wp-content/uploads/2026/07/garanta*.png$image
+
 !#include road-ubo.txt


### PR DESCRIPTION
Hides the ads from the website, like these ones:
<img width="1749" height="612" alt="image" src="https://github.com/user-attachments/assets/b021f32d-3460-41cc-ba8e-0a3edbecc3c7" />
